### PR TITLE
WESTPA HDF5 framework compatibility

### DIFF
--- a/synd/westpa/augmentation_driver.py
+++ b/synd/westpa/augmentation_driver.py
@@ -52,9 +52,10 @@ class SynDAugmentationDriver:
         n_walkers = len(segments)
 
         # Create auxdata/coord for the current iteration
-        self.data_manager.we_h5file.create_dataset(
+        self.data_manager.we_h5file.require_dataset(
             f"{iter_group.name}/auxdata/coord",
             shape=(n_walkers, 2, *feature_shape),
+            dtype=self.coord_map[0].dtype
         )
 
         self.data_manager.flush_backing()

--- a/synd/westpa/augmentation_driver.py
+++ b/synd/westpa/augmentation_driver.py
@@ -65,7 +65,13 @@ class SynDAugmentationDriver:
         for i, segment in enumerate(segments):
 
             segment_state_index = get_segment_index(segment)
-            parent_state_index = get_segment_parent_index(segment)
+
+            try:
+                parent_state_index = get_segment_parent_index(segment)
+            except AttributeError as e:
+                # This should only trigger when restarting -- instead of doing this, we could just check
+                #   to see if this iteration has already been augmented for this segment.
+                continue
 
             auxcoord_dataset[segment.seg_id, 0] = self.coord_map[parent_state_index]
             auxcoord_dataset[segment.seg_id, 1] = self.coord_map[segment_state_index]

--- a/synd/westpa/propagator.py
+++ b/synd/westpa/propagator.py
@@ -67,14 +67,11 @@ def get_segment_parent_index(segment):
             }
             }
             data_manager.dataset_options.update(new_options)
-            westpa.rc.pstatus(data_manager.dataset_options)
 
-            westpa.rc.pstatus(f"Parent id is {segment.parent_id}")
+            # This is documented as having a load_auxdata parameter... but it doesn't.
             actual_parent_segment = data_manager.get_segments(parent_segment.n_iter,
                                                               seg_ids=[parent_segment.seg_id])[0]
             data_manager.dataset_options = og_dataset_options
-
-            westpa.rc.pstatus(actual_parent_segment.data)
 
             parent_state_index = actual_parent_segment.data["state_indices"][-1]
 

--- a/synd/westpa/propagator.py
+++ b/synd/westpa/propagator.py
@@ -48,8 +48,16 @@ def get_segment_parent_index(segment):
 
     if not parent_was_ibstate:
 
-        parent_map = sim_manager.we_driver._parent_map
-        parent_segment = parent_map[segment.parent_id]
+        if hasattr(sim_manager.we_driver, '_parent_map'):
+            parent_map = sim_manager.we_driver._parent_map
+            parent_segment = parent_map[segment.parent_id]
+        else:
+            # If we're continuing a stopped run, _parent_map may not be populated.
+            # In that case, how do we get the parent segment?
+
+            # I think in that case, though, we've already augmented the segment.. so we're fine to just do nothing
+            raise AttributeError
+
 
         try:
             parent_state_index = parent_segment.data["state_indices"][-1]


### PR DESCRIPTION
Makes the SynD propagator compatible with the WESTPA HDF5 coordinate augmentation framework

Note that, although this is provided to make them compatible, it's still FAR more efficient to do augmentation with the `SynD.westpa.augmentation_driver`, because the H5 framework still requires file IO.

Before merging this, sort out:
- [ ] Do I want to keep `topology` as a required parameter to the propagator? Or store it on the model?

    I kinda liked having the propagator take no arguments at all, but then again, I don't want to tie the Markov SynD model to MD by putting a topology field on it.

   I could further subclass it to `MDMarkovModel`, but that seems a little clunky and over-specialized just to store one extra attribute..