### PR TITLE
Merge WESTPA compatibility changes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires      = ["setuptools", "wheel"]
 
 [project]
 name = "SynD"
-version = "0.1.2"
+version = "0.1.3.dev1"
 description = "Synthetic dynamics for trajectory generation"
 readme = "README.md"
 authors = [{ name = "John Russo", email = "russojd@ohsu.edu" }]

--- a/synd/westpa/__init__.py
+++ b/synd/westpa/__init__.py
@@ -1,0 +1,2 @@
+from .augmentation_driver import SynDAugmentationDriver
+from .propagator import SynMDPropagator

--- a/synd/westpa/augmentation_driver.py
+++ b/synd/westpa/augmentation_driver.py
@@ -65,13 +65,7 @@ class SynDAugmentationDriver:
         for i, segment in enumerate(segments):
 
             segment_state_index = get_segment_index(segment)
-
-            try:
-                parent_state_index = get_segment_parent_index(segment)
-            except AttributeError as e:
-                # This should only trigger when restarting -- instead of doing this, we could just check
-                #   to see if this iteration has already been augmented for this segment.
-                continue
+            parent_state_index = get_segment_parent_index(segment)
 
             auxcoord_dataset[segment.seg_id, 0] = self.coord_map[parent_state_index]
             auxcoord_dataset[segment.seg_id, 1] = self.coord_map[segment_state_index]

--- a/synd/westpa/augmentation_driver.py
+++ b/synd/westpa/augmentation_driver.py
@@ -52,9 +52,10 @@ class SynDAugmentationDriver:
         n_walkers = len(segments)
 
         # Create auxdata/coord for the current iteration
-        self.data_manager.we_h5file.create_dataset(
+        self.data_manager.we_h5file.require_dataset(
             f"{iter_group.name}/auxdata/coord",
             shape=(n_walkers, 2, *feature_shape),
+            dtype=self.coord_map[0].dtype
         )
 
         self.data_manager.flush_backing()

--- a/synd/westpa/augmentation_driver.py
+++ b/synd/westpa/augmentation_driver.py
@@ -65,7 +65,13 @@ class SynDAugmentationDriver:
         for i, segment in enumerate(segments):
 
             segment_state_index = get_segment_index(segment)
-            parent_state_index = get_segment_parent_index(segment)
+
+            try:
+                parent_state_index = get_segment_parent_index(segment)
+            except AttributeError as e:
+                # This should only trigger when restarting -- instead of doing this, we could just check
+                #   to see if this iteration has already been augmented for this segment.
+                continue
 
             auxcoord_dataset[segment.seg_id, 0] = self.coord_map[parent_state_index]
             auxcoord_dataset[segment.seg_id, 1] = self.coord_map[segment_state_index]

--- a/synd/westpa/propagator.py
+++ b/synd/westpa/propagator.py
@@ -60,9 +60,9 @@ def get_segment_parent_index(segment):
 
         else:
             prev_segments = data_manager.get_segments(
-                n_iter=segment.n_iter - 1, load_pcoords=True
+                n_iter=segment.n_iter - 1, seg_ids=[segment.parent_id], load_pcoords=False
             )
-            parent_state_index = get_segment_index(prev_segments[segment.parent_id])
+            parent_state_index = get_segment_index(prev_segments[0])
 
     # Otherwise, that means the segment was a bstate/istate
     else:

--- a/synd/westpa/propagator.py
+++ b/synd/westpa/propagator.py
@@ -67,14 +67,11 @@ def get_segment_parent_index(segment):
             }
             }
             data_manager.dataset_options.update(new_options)
-            westpa.rc.pstatus(data_manager.dataset_options)
 
-            westpa.rc.pstatus(f"Parent id is {segment.parent_id}")
+            # This is documented as having a load_auxdata parameter... but it doesn't.
             actual_parent_segment = data_manager.get_segments(parent_segment.n_iter,
                                                               seg_ids=[parent_segment.seg_id])[0]
             data_manager.dataset_options = og_dataset_options
-
-            westpa.rc.pstatus(actual_parent_segment.data)
 
             parent_state_index = actual_parent_segment.data["state_indices"][-1]
 

--- a/synd/westpa/propagator.py
+++ b/synd/westpa/propagator.py
@@ -48,8 +48,16 @@ def get_segment_parent_index(segment):
 
     if not parent_was_ibstate:
 
-        parent_map = sim_manager.we_driver._parent_map
-        parent_segment = parent_map[segment.parent_id]
+        if hasattr(sim_manager.we_driver, '_parent_map'):
+            parent_map = sim_manager.we_driver._parent_map
+            parent_segment = parent_map[segment.parent_id]
+        else:
+            # If we're continuing a stopped run, _parent_map may not be populated.
+            # In that case, how do we get the parent segment?
+
+            # I think in that case, though, we've already augmented the segment.. so we're fine to just do nothing
+            raise AttributeError
+
 
         try:
             parent_state_index = parent_segment.data["state_indices"][-1]

--- a/synd/westpa/propagator.py
+++ b/synd/westpa/propagator.py
@@ -36,8 +36,19 @@ def get_segment_index(segment):
 
 def get_segment_parent_index(segment):
     """
-    For a given segment, identify the discrete index of its parent
+    For a given segment, identify the discrete index of its parent.
+
+    For parents that are plain segments, get it from the auxdata.
+
+    For parents that are initial/basis states, get it from the state definition's auxref.
     """
+
+    # Note that this is invoked at the beginning of propagation, to obtain initial positions for each segment,
+    #   and also in augmentation.
+    # At the beginning of propagation, nothing's been written to the H5 file yet, so we can't use westpa.analysis
+    #   to obtain the parent.
+    # In augmentation, it's fine in theory to just look in the H5 file (i.e. with westpa.analysis), but it comes
+    #   at a massive performance hit.
 
     sim_manager = westpa.rc.get_sim_manager()
     data_manager = westpa.rc.get_data_manager()


### PR DESCRIPTION
These changes are largely related to adding optional compatibility with ~~the HDF5 framework for~~ WESTPA

This includes
- Adding multiple backmappers to a model (for WESTPA, you likely want a backmapper to progress coordinate, and a backmapper to full coordinates for H5 augmentation)
- Efficeincy improvements to minimize file IO  ea24cf7cb8086f043a09cb061d1400dfde2544cf