### PR TITLE
Fixing the Random Number Generator Bug from pickled objects

### DIFF
--- a/synd/core.py
+++ b/synd/core.py
@@ -3,9 +3,9 @@ import pickle
 import numpy as np
 from numpy.random import default_rng
 try:
-    import packaging
+    from packaging.version import parse
 except ModuleNotFoundError:
-    from pkg_resources import packaging
+    from pkg_resources import parse_version as parse
 
 
 def load_model(filename: str, randomize: bool = True):
@@ -28,6 +28,6 @@ def load_model(filename: str, randomize: bool = True):
     if randomize:
         model.rng = default_rng(seed=None)
 
-    model.numpy_version_greater = packaging.version.Version(np.__version__) >= packaging.version.Version('1.25.0')
+    model.numpy_version_greater = parse(np.__version__) >= parse('1.25.0')
 
     return model

--- a/synd/core.py
+++ b/synd/core.py
@@ -1,8 +1,8 @@
 """Functions for interacting with SynD models."""
 import pickle
+from numpy.random import default_rng
 
-
-def load_model(filename: str):
+def load_model(filename: str, randomize: bool = True):
     """
     Load a SynD model from a file.
 
@@ -18,5 +18,8 @@ def load_model(filename: str):
 
     with open(filename, 'rb') as infile:
         model = pickle.load(infile)
+
+    if randomize:
+        model.rng = default_rng(seed=None)
 
     return model

--- a/synd/core.py
+++ b/synd/core.py
@@ -1,6 +1,12 @@
 """Functions for interacting with SynD models."""
 import pickle
+import numpy as np
 from numpy.random import default_rng
+try:
+    import packaging
+except ModuleNotFoundError:
+    from pkg_resources import packaging
+
 
 def load_model(filename: str, randomize: bool = True):
     """
@@ -21,5 +27,7 @@ def load_model(filename: str, randomize: bool = True):
 
     if randomize:
         model.rng = default_rng(seed=None)
+
+    model.numpy_version_greater = packaging.version.Version(np.__version__) >= packaging.version.Version('1.25.0')
 
     return model

--- a/synd/models/base.py
+++ b/synd/models/base.py
@@ -4,6 +4,7 @@ import logging
 from rich.logging import RichHandler
 import pickle
 import numpy as np
+
 try:
     from packaging.version import parse
 except ModuleNotFoundError:

--- a/synd/models/base.py
+++ b/synd/models/base.py
@@ -3,6 +3,7 @@ from abc import ABC
 import logging
 from rich.logging import RichHandler
 import pickle
+import numpy as np
 try:
     from packaging.version import parse
 except ModuleNotFoundError:
@@ -25,7 +26,7 @@ class BaseSynDModel(ABC):
     def __init__(self):
 
         self.logger = logger
-        self.numpy_version_greater = parse(numpy.__version__) >= parse('1.25.0')
+        self.numpy_version_greater = parse(np.__version__) >= parse('1.25.0')
 
     def serialize(self):
         """

--- a/synd/models/base.py
+++ b/synd/models/base.py
@@ -3,6 +3,10 @@ from abc import ABC
 import logging
 from rich.logging import RichHandler
 import pickle
+try:
+    import packaging
+except ModuleNotFoundError:
+    from pkg_resources import packaging
 
 logger = logging.getLogger(__name__)
 
@@ -21,6 +25,7 @@ class BaseSynDModel(ABC):
     def __init__(self):
 
         self.logger = logger
+        self.numpy_version_greater = packaging.version.Version(numpy.__version__) >= packaging.version.Version('1.25.0')
 
     def serialize(self):
         """

--- a/synd/models/base.py
+++ b/synd/models/base.py
@@ -4,9 +4,9 @@ import logging
 from rich.logging import RichHandler
 import pickle
 try:
-    import packaging
+    from packaging.version import parse
 except ModuleNotFoundError:
-    from pkg_resources import packaging
+    from pkg_resources import parse_version as parse
 
 logger = logging.getLogger(__name__)
 
@@ -25,7 +25,7 @@ class BaseSynDModel(ABC):
     def __init__(self):
 
         self.logger = logger
-        self.numpy_version_greater = packaging.version.Version(numpy.__version__) >= packaging.version.Version('1.25.0')
+        self.numpy_version_greater = parse(numpy.__version__) >= parse('1.25.0')
 
     def serialize(self):
         """

--- a/synd/models/discrete/markov.py
+++ b/synd/models/discrete/markov.py
@@ -1,6 +1,5 @@
 from __future__ import annotations  # Sets PEP563, necessary for autodoc type aliases
 from synd.models.discrete.discrete import DiscreteGenerator
-from packaging.version import Version
 import numpy as np
 from numpy.typing import ArrayLike
 from typing import Callable, Union

--- a/synd/models/discrete/markov.py
+++ b/synd/models/discrete/markov.py
@@ -1,5 +1,6 @@
 from __future__ import annotations  # Sets PEP563, necessary for autodoc type aliases
 from synd.models.discrete.discrete import DiscreteGenerator
+from packaging.version import Version
 import numpy as np
 from numpy.typing import ArrayLike
 from typing import Callable, Union
@@ -35,7 +36,7 @@ class MarkovGenerator(DiscreteGenerator):
 
         self.rng = np.random.default_rng(seed=seed)
 
-        self.numpy_version_greater = Version(numpy.__version__) >= Version('1.25.0')
+        self.numpy_version_greater = Version(np.__version__) >= Version('1.25.0')
 
         self.cumulative_probabilities = np.cumsum(self.transition_matrix, axis=1)
 

--- a/synd/models/discrete/markov.py
+++ b/synd/models/discrete/markov.py
@@ -6,6 +6,11 @@ from numpy.typing import ArrayLike
 from typing import Callable, Union
 from scipy import sparse
 
+try:
+    from packaging.version import parse
+except ModuleNotFoundError:
+    from pkg_resources import parse_version as parse
+
 
 class MarkovGenerator(DiscreteGenerator):
     """
@@ -36,7 +41,7 @@ class MarkovGenerator(DiscreteGenerator):
 
         self.rng = np.random.default_rng(seed=seed)
 
-        self.numpy_version_greater = Version(np.__version__) >= Version('1.25.0')
+        self.numpy_version_greater = parse(np.__version__) >= parse('1.25.0')
 
         self.cumulative_probabilities = np.cumsum(self.transition_matrix, axis=1)
 

--- a/synd/models/discrete/markov.py
+++ b/synd/models/discrete/markov.py
@@ -117,7 +117,7 @@ class MarkovGenerator(DiscreteGenerator):
 
         trajectories[:, 0] = initial_states
 
-        probabilities = self.rng.random(size=(n_trajectories, n_steps - 1))
+        probabilities = np.asarray([generator.random(n_steps -1) for generator in self.rng.spawn(n_trajectories)])
 
         for istep in range(1, n_steps):
             current_states = trajectories[:, istep - 1]

--- a/synd/models/discrete/markov.py
+++ b/synd/models/discrete/markov.py
@@ -122,7 +122,7 @@ class MarkovGenerator(DiscreteGenerator):
         if self.numpy_version_greater:
             probabilities = np.asarray([generator.random(n_steps -1) for generator in self.rng.spawn(n_trajectories)])
         else:
-             probabilities = np.asarray([np.random.default_rng().random(n_steps -1) for i in range(n_trajectories)])
+             probabilities = np.asarray([np.random.default_rng(seed=seed).random(n_steps -1) for seed in self.rng.bit_generator._seed_seq.spawn(n_trajectories)])
 
         for istep in range(1, n_steps):
             current_states = trajectories[:, istep - 1]

--- a/synd/models/discrete/markov.py
+++ b/synd/models/discrete/markov.py
@@ -35,6 +35,8 @@ class MarkovGenerator(DiscreteGenerator):
 
         self.rng = np.random.default_rng(seed=seed)
 
+        self.numpy_version_greater = Version(numpy.__version__) >= Version('1.25.0')
+
         self.cumulative_probabilities = np.cumsum(self.transition_matrix, axis=1)
 
         self.logger.info(f"Discrete Markov model created with {self.n_states} states successfully created")
@@ -117,7 +119,10 @@ class MarkovGenerator(DiscreteGenerator):
 
         trajectories[:, 0] = initial_states
 
-        probabilities = np.asarray([generator.random(n_steps -1) for generator in self.rng.spawn(n_trajectories)])
+        if self.numpy_version_greater:
+            probabilities = np.asarray([generator.random(n_steps -1) for generator in self.rng.spawn(n_trajectories)])
+        else:
+             probabilities = np.asarray([np.random.default_rng().random(n_steps -1) for i in range(n_trajectories)])
 
         for istep in range(1, n_steps):
             current_states = trajectories[:, istep - 1]

--- a/synd/westpa/propagator.py
+++ b/synd/westpa/propagator.py
@@ -176,13 +176,11 @@ class SynMDPropagator(WESTPropagator):
 
 	# Determine seed and whether to randomize RNG
         rng_seed = rc.config.get(['west', 'propagation', 'parameters', 'rng_seed'], None)
-        randomize = rc.config.get(['west', 'propagation', 'parameters', 'randomize'], True)
+        randomize = rc.config.get(['west', 'propagation', 'parameters', 'randomize'], True)  # Default to randomize RNG
 
         if 'synd_model' in rc_paramters.keys():
             model_path = rc_parameters['synd_model']
-            self.synd_model = synd.core.load_model(model_path)
-            if randomize:
-                self.synd_model.rng = np.random.default_rng(seed=rng_seed)  # Replacing the pickled RNG with new generator
+            self.synd_model = synd.core.load_model(model_path, randomize)
         else:
             pcoord_map_path = rc_parameters['pcoord_map']
             with open(pcoord_map_path, 'rb') as inf:

--- a/tests/test_synd.py
+++ b/tests/test_synd.py
@@ -69,9 +69,11 @@ class TestSynd(unittest.TestCase):
 
         self.synmd_model.save("simple_synmd_model.dat")
 
-        loaded_model = load_model("simple_synmd_model.dat")
+        loaded_model = load_model("simple_synmd_model.dat", randomize=True)
 
         assert isinstance(loaded_model, MarkovGenerator)
+
+        assert loaded_model.rng.random() != self.synmd_model.rng.random()
 
         os.remove("simple_synmd_model.dat")
 


### PR DESCRIPTION
When loading a model from a `XXX.synd` pickle object (like `trpcage.synd`), a previously-initialized random number generator (RNG) is used, so any trajectory generated from the loaded pickle are deterministic.  You can test it by running the sample code below multiple times; the resulting output is exactly the same.  Un-commenting line 7, which will create a new RNG each time, will fix that.

This branch contains all the necessary fixes for sufficiently randomized runs.  These include the following changes:

1) By default, [the random number generator is reinitialized with a new entropy-derived seed when a model is loaded](https://github.com/jeremyleung521/SynD/blob/rng-fix/synd/core.py#L22-L23).  I added a `randomize` argument to `load_model()` to suppress randomization, which could be useful when reproducibility is needed.
2) When running with the WESTPA propagator, [the seed is reinitialized every iteration](https://github.com/jeremyleung521/SynD/blob/rng-fix/synd/westpa/propagator.py#L241-L242). New options like `randomize` and `rng_seed` can be added to the `west.cfg` to suppress randomization for testing.
3) [Generated trajectories will be pulled from independent streams](https://github.com/jeremyleung521/SynD/blob/rng-fix/synd/models/discrete/markov.py#L120), instead of from the same random sequence.  While the output will still be deterministic, this is contingent on the seed. The new seeds from 1) and 2) should produce sufficient randomness between iterations.


Test Script (need to manually run this multiple times):
```
import numpy as np
from synd.core import load_model

model = load_model('synd_model/ntl9_folding.synd')

# Uncomment the following lines to create a new generator every time.
#model.rng = np.random.default_rng()
print(model.rng.random())

discrete_trajectory = model.generate_trajectory(
    initial_states=np.array([121]),
    # 1 step is 10 ps
    n_steps=10
)

print(f'discrete: {discrete_trajectory}')
```